### PR TITLE
refactor: Unify both claude llm interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .coverage
 coverage.xml
 memory_graph.json
+/.llm_cache.json

--- a/cybermule/prompts/refactor.prompt
+++ b/cybermule/prompts/refactor.prompt
@@ -1,32 +1,33 @@
-You are a Python code refactoring assistant. Your task is to refactor a given Python code snippet according to a specific goal. Follow these steps:
-
-1. First, you will be presented with the Python code to be refactored:
+You are a Python code refactoring assistant. Your task is to refactor a given Python code snippet according to a specific goal. Here's the code you need to refactor:
 
 <python_code>
 {PYTHON_CODE}
 </python_code>
 
-2. Next, you will be given a specific refactoring goal:
+And here's the refactoring goal:
 
 <refactoring_goal>
 {REFACTORING_GOAL}
 </refactoring_goal>
 
-3. Analyze the code:
-   - Understand the current structure and functionality of the code.
-   - Identify areas that can be improved according to the refactoring goal.
-   - Consider Python best practices and common design patterns that could be applied.
+Follow these steps to complete the task:
 
-4. Refactor the code:
-   - Make changes to the code to achieve the refactoring goal.
-   - Ensure that the functionality of the code remains the same unless the goal specifically requires functional changes.
-   - Follow Python style guidelines (PEP 8) in your refactored code.
-   - Use meaningful variable and function names.
-   - Add comments where necessary to explain complex logic.
+1. Analyze the code and the refactoring goal.
+2. Identify areas that can be improved to meet the refactoring goal.
+3. Apply appropriate refactoring techniques.
+4. Ensure the functionality of the code remains the same unless the goal specifically requires functional changes.
+5. Follow Python style guidelines (PEP 8) in your refactored code.
+6. Use meaningful variable and function names.
+7. Add comments where necessary to explain complex logic.
 
-5. Output the refactored code:
-   - Present the refactored code in a code block, using triple backticks for formatting.
-   - Start the code block with ```python and end it with ```.
+Before presenting the final refactored code, wrap your thought process inside <refactoring_analysis> tags. In your analysis:
+- List the main functions/classes in the code
+- Identify specific code smells or anti-patterns
+- Propose refactoring techniques for each identified issue
+- Consider the current structure and functionality of the code
+- Identify specific areas that need improvement based on the refactoring goal
+- Note Python best practices and design patterns that could be applied
+- Discuss any potential challenges, trade-offs, or performance impacts in the refactoring process
 
-Remember, the goal is to improve the code according to the given refactoring goal while maintaining its original functionality (unless otherwise specified).
-Be thorough in your refactoring.
+After your analysis, present ONLY the refactored code in a Python code block, starting with ```python and ending with ```.
+Remember to preserve the quality of the generated code and focus solely on providing the refactored code as the final output.


### PR DESCRIPTION
Refactor is generated by GenAI:

Main functions/classes in the code:
1. `LLMProvider` - Base abstract class for all LLM providers
2. `ClaudeBedrockProvider` - Implementation for AWS Bedrock Claude
3. `OllamaProvider` - Implementation for Ollama
4. `MockLLMProvider` - Mock implementation for testing
5. `ClaudeDirectProvider` - Implementation for Claude Direct API
6. `get_llm_provider` - Factory function to create provider instances

Looking at the refactoring goal, we need to:
- Create a new base class for Claude providers
- This class should extract common functionality from both Claude implementations
- Avoid using "if" statements for the unification

Specific issues to address:
1. Both Claude providers (`ClaudeBedrockProvider` and `ClaudeDirectProvider`) have similar parameters:
   - model_id
   - temperature
   - max_tokens
   - system_prompt (only in `ClaudeBedrockProvider`, but could be useful for both)

2. Both providers have different message formatting and API calls, but the structure is similar.

Refactoring approach:
1. Create a new `ClaudeBaseProvider` class that inherits from `LLMProvider`
2. Move common parameters and initialization to this base class
3. Create an abstract method for the API-specific implementation
4. Have both Claude provider classes inherit from this new base class
5. Implement the specific API calls in each subclass

This approach follows the Template Method pattern, where the base class defines the skeleton of an algorithm, deferring some steps to subclasses. This allows us to reuse code without introducing conditional logic.

Potential challenges:
- Ensuring consistent behavior across both implementations
- Handling potential differences in API responses
- Maintaining backward compatibility

--
Also update the refactor prompt